### PR TITLE
Admin approval 

### DIFF
--- a/backend/controllers/cohorts.c.js
+++ b/backend/controllers/cohorts.c.js
@@ -1,4 +1,4 @@
-import { _all } from '../models/cohorts.m.js'
+import { _all, _unverifiedRequests } from '../models/cohorts.m.js'
 import dotenv from 'dotenv'
 dotenv.config()
 
@@ -6,8 +6,18 @@ export const all = async(req, res) => {
     try {
         const cohorts = await _all()
         return res.json(cohorts)
-    } catch {
+    } catch (error) {
         console.log("all", error)
         res.status(404).json({msg: "Cohorts not found"})
+    }
+}
+
+export const unverifiedRequests = async(req, res) => {
+    try {
+        const unverifiedRequests = await _unverifiedRequests()
+        return res.json(unverifiedRequests)
+    } catch (error) {
+        console.log("unverifiedRequests", error)
+        res.status(404).json({msg: "Unverified cohort request not found"})
     }
 }

--- a/backend/controllers/users.c.js
+++ b/backend/controllers/users.c.js
@@ -155,9 +155,7 @@ export const updateUser = async(req, res) => {
     try {
         const { id } = req.params
         let updatedUser = {};
-        console.log('hello')
 
-        
         if (req.body.cohort) {
             const cohort = req.body.cohort
             await db('users').update({cohort_id: cohort}).where({id: id})
@@ -166,7 +164,6 @@ export const updateUser = async(req, res) => {
 
         if (req.body.step) {
             const step = req.body.step
-            console.log(step)
             await db('users').update({step: step}).where({id: id})
             updatedUser.step = step
         }
@@ -178,6 +175,12 @@ export const updateUser = async(req, res) => {
             await db('users').update({ biography, profile_picture: profile_picture }).where({ id });
             updatedUser.profile_picture = profile_picture
             updatedUser.biography = biography
+        }
+
+        if (req.body.verifyRequest) {
+            const verifyRequest = req.body.verifyRequest
+            await db('users').update({isverified: verifyRequest}).where({id: id})
+            updatedUser.isverified = verifyRequest
         }
 
         res.status(200).json(updatedUser);

--- a/backend/models/cohorts.m.js
+++ b/backend/models/cohorts.m.js
@@ -9,3 +9,13 @@ export const _all = async() => {
         throw new Error("Could not retrieve cohorts")
     }
 }
+
+export const _unverifiedRequests = async() => {
+    try {
+        const unverifiedRequests = await db('cohort').join('users', 'users.cohort_id', 'cohort.id').select('cohort.name', 'users.id', 'users.first_name', 'users.last_name', 'users.email').where('users.isverified', false)
+        return unverifiedRequests || null
+    } catch (error) {
+        console.log("Error in fetching unverified cohort requests", error)
+        throw new Error("Could not retrieve requests")
+    }
+}

--- a/backend/routes/cohorts.r.js
+++ b/backend/routes/cohorts.r.js
@@ -1,8 +1,9 @@
 import express from 'express'
-import { all  } from '../controllers/cohorts.c.js'
+import { all, unverifiedRequests  } from '../controllers/cohorts.c.js'
 
 const router = express.Router()
 
 router.get('/cohorts/all', all)
+router.get('/cohorts/unverified', unverifiedRequests)
 
 export default router

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.15.19",
     "@mui/joy": "^5.0.0-beta.36",
     "@mui/material": "^5.15.19",
+    "@mui/x-data-grid": "^7.6.2",
     "@reduxjs/toolkit": "^2.2.5",
     "axios": "^1.7.2",
     "cloudinary-react": "^1.8.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,44 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom'
 import LoginRegister from './components/LoginRegister.tsx'
-import Logout from './components/Logout.tsx';
-import Nav from './components/Nav.tsx';
-import Auth from './components/auth/Auth.tsx';
-import Home from './components/Home.tsx';
+import Logout from './components/Logout.tsx'
+import Nav from './components/Nav.tsx'
+import Auth from './components/auth/Auth.tsx'
+import Home from './components/Home.tsx'
+import Admin from './components/admin/Admin.tsx'
 import { createContext, useState } from 'react'
 import './App.css'
 import { AuthContextType, UserInterface } from './types/consts'
-import UserDetailsForm from './components/userDetails/UserDetailsForm.tsx';
-
+import UserDetailsForm from './components/userDetails/UserDetailsForm.tsx'
+import { useEffect } from 'react'
 
 const initialValue = {
   user: null,
-  setUser: () => {}
+  setUser: () => {},
+  token: null,
+  setToken: () => {}
 }
 
 export const AuthContext = createContext<AuthContextType>(initialValue)
 
 function App() {
     const [user, setUser] = useState<UserInterface | null>(null)
+    const [token, setToken] = useState<string | null>(null)
 
+    useEffect(() => {
+      const storedToken = localStorage.getItem('token')
+      const storedUser = localStorage.getItem('user')
+  
+      if (storedToken) {
+        setToken(storedToken)
+      }
+  
+      if (storedUser) {
+        setUser(JSON.parse(storedUser))
+      }
+    }, []);
+  
     return (
-      <AuthContext.Provider value={{user, setUser}}>
+      <AuthContext.Provider value={{ user, setUser, token, setToken }}>
           <Nav/>
           <div>
             <Routes>
@@ -29,6 +46,7 @@ function App() {
               <Route path='/register' element={<LoginRegister page={"Register"}/>}/>
               <Route path='/logout' element={<Logout/>}/>
               <Route path='/home' element={<Auth><Home><UserDetailsForm/></Home></Auth>}/>
+              <Route path='/admin' element={<Auth><Admin/></Auth>}/>
             </Routes>
           </div>
       </AuthContext.Provider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import LoginRegister from './components/LoginRegister.tsx'
 import Logout from './components/Logout.tsx'
 import Nav from './components/Nav.tsx'
@@ -46,7 +46,7 @@ function App() {
               <Route path='/register' element={<LoginRegister page={"Register"}/>}/>
               <Route path='/logout' element={<Logout/>}/>
               <Route path='/home' element={<Auth><Home><UserDetailsForm/></Home></Auth>}/>
-              <Route path='/admin' element={<Auth><Admin/></Auth>}/>
+              <Route path='/admin' element={<Auth>{user && user.isadmin ? <Admin /> : <Navigate to="/login"/>}</Auth>}/>
             </Routes>
           </div>
       </AuthContext.Provider>

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,9 +1,10 @@
 import { configureStore, combineReducers} from "@reduxjs/toolkit";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import userDetailsReducer from "../components/userDetails/slice"
+import adminReducer from "../components/admin/slice"
 
 
-const combineReducersApp = combineReducers({userDetailsReducer})
+const combineReducersApp = combineReducers({userDetailsReducer, adminReducer})
 
 const store = configureStore({
     reducer: combineReducersApp

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -32,7 +32,6 @@ const Home = ({children}: HomeProps) => {
       <div className='container'>
         {children}
       </div>  
-   
     </>
   );
 };

--- a/frontend/src/components/LoginRegister.tsx
+++ b/frontend/src/components/LoginRegister.tsx
@@ -17,7 +17,7 @@ const LoginRegister = ({page}: LoginRegisterProps) => {
 
     const [message, setMessage] = useState<string>('')
 
-    const { setUser } = useContext(AuthContext)
+    const { setUser, setToken } = useContext(AuthContext)
 
     const navigate = useNavigate()
 
@@ -44,18 +44,20 @@ const LoginRegister = ({page}: LoginRegisterProps) => {
             }
         } else {
             // on login
-            console.log("hellooo", import.meta.env.VITE_BACKEND_URL)
             try {
                 const response = await axios.post(import.meta.env.VITE_BACKEND_URL + '/login', {
                     email, password
                 }, {withCredentials: true})
 
-                if(response.status === 200) {
-                    setMessage("")
-                    console.log(response.data)
-                    setUser(response.data)
-                    navigate('/home')
-                }
+                if (response.status === 200) {
+                    setMessage("");
+                    setUser(response.data);
+                    const token = response.data.token;
+                    setToken(token);
+                    localStorage.setItem('token', token);
+                    localStorage.setItem('user', JSON.stringify(response.data));
+                    navigate('/home');
+                  }
             } catch (error) {
                 if (axios.isAxiosError(error)) {
                   const errorMessage = error.response?.data?.msg || 'An error occurred';

--- a/frontend/src/components/Logout.tsx
+++ b/frontend/src/components/Logout.tsx
@@ -9,12 +9,15 @@ const Logout = () => {
 
   useEffect(() => {
     logoutUser()
+    localStorage.removeItem('token')
+    localStorage.removeItem('user')
     setUser(null)
   }, [])
 
   const logoutUser = async() => {
     try {
         await axios.post(import.meta.env.VITE_BACKEND_URL + '/logout', null, { withCredentials: true})
+
         navigate('/login')
     } catch (error) {
         console.log('logging out', error)

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -26,6 +26,7 @@ const Nav = () => {
             Alumni Network
           </Typography>
           <Stack direction='row' spacing={2}>
+            {user?.token && user.isadmin ? <Button component={Link} to='/admin' color="inherit">Admin</Button> : null }
             {user?.token ? <Button component={Link} to='/home' color="inherit">Home</Button> : null }
             <Button component={Link} to='/login' color="inherit">Login</Button>
             <Button component={Link} to='/register' color="inherit">Register</Button>

--- a/frontend/src/components/ProfilePicture.tsx
+++ b/frontend/src/components/ProfilePicture.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext, useState } from "react"
 import axios from 'axios'
 import { AuthContext } from "../App"
+import { Avatar } from "@mui/material"
 
 const ProfilePicture = () => {
   const { user } = useContext(AuthContext)
@@ -17,7 +18,7 @@ const ProfilePicture = () => {
   }, [profilePic])  
 
   return (
-        <img src={profilePic} style={{ width: '150px', height: '150px' }} alt="Profile Picture" />
+    <Avatar alt="Profile Picture" src={profilePic} sx={{ width: 150, height: 150 }}/>
   )
 }
 

--- a/frontend/src/components/admin/Admin.css
+++ b/frontend/src/components/admin/Admin.css
@@ -1,0 +1,5 @@
+.container1 {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/frontend/src/components/admin/Admin.tsx
+++ b/frontend/src/components/admin/Admin.tsx
@@ -3,6 +3,7 @@ import { useContext, useEffect } from "react"
 import Table from "./Table"
 import './Admin.css'
 import { AuthContext } from "../../App"
+import ProfilePicture from "../ProfilePicture"
 
 const Admin = () => {
   const cohortUserDetails = useCohortUserDetails()
@@ -15,7 +16,8 @@ const Admin = () => {
 
   return (
       <>
-          <h2>Welcome {user?.first_name}{user?.last_name}</h2>
+          <h2>Check the cohort requests {user?.first_name} {user?.last_name}</h2>
+          <ProfilePicture/>
           <div className='container1'>
             <Table cohortUserDetails={cohortUserDetails} />
           </div>

--- a/frontend/src/components/admin/Admin.tsx
+++ b/frontend/src/components/admin/Admin.tsx
@@ -1,9 +1,26 @@
+import { useCohortUserDetails, useFetchCohortUserDetails } from "./hooks"
+import { useContext, useEffect } from "react"
+import Table from "./Table"
+import './Admin.css'
+import { AuthContext } from "../../App"
+
 const Admin = () => {
+  const cohortUserDetails = useCohortUserDetails()
+  const fetchCohortUserDetails = useFetchCohortUserDetails()
+  const { user } = useContext(AuthContext)
+
+  useEffect(() => {
+    fetchCohortUserDetails();
+  }, []); 
+
   return (
-    <div>Admin</div>
-
-    
-
+      <>
+          <h2>Welcome {user?.first_name}{user?.last_name}</h2>
+          <div className='container1'>
+            <Table cohortUserDetails={cohortUserDetails} />
+          </div>
+      </>
+ 
   )
 }
 

--- a/frontend/src/components/admin/Table.tsx
+++ b/frontend/src/components/admin/Table.tsx
@@ -1,0 +1,84 @@
+import { DataGrid, GridColDef, GridRowSelectionModel } from '@mui/x-data-grid';
+import { useState, useEffect } from 'react';
+import { CohortUserDetails } from '../../types/consts';
+import axios from 'axios'
+import { Alert } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+
+const columns: GridColDef[] = [
+  { field: 'id', headerName: 'ID', width: 70 },
+  { field: 'first_name', headerName: 'First name', width: 130 },
+  { field: 'last_name', headerName: 'Last name', width: 130 },
+  { field: 'email', headerName: 'Email address', width: 130},
+  { field: 'name', headerName: 'Cohort name', width: 200}
+];
+
+const Table = (props: { cohortUserDetails: CohortUserDetails[] })=> {
+  const [rows, setRows] = useState<CohortUserDetails[]>([]);
+  const [rowSelectionModel, setRowSelectionModel] = useState<GridRowSelectionModel>([])
+  const [alert, setAlert] = useState<boolean>(false)
+  const [alertContent, setAlertContent] = useState<string>('')
+
+  useEffect(() => {
+    setRows(props.cohortUserDetails)
+  }, [props.cohortUserDetails])
+
+  const handleSelection = async (rowSelected: GridRowSelectionModel) => {
+    if(rowSelected.length > 0) {
+        setRowSelectionModel(rowSelected);
+
+        let userID: number | undefined;
+        userID = parseInt(rowSelected[0] as string)
+
+    try {
+        if (userID !== undefined) { 
+            const requestDetails = {
+                userID,
+                verifyRequest: true
+            };
+
+            const response = await axios.put(import.meta.env.VITE_BACKEND_URL + `/users/${userID}`, requestDetails)
+            
+            if (response.status === 200) {
+                const remainingRows = rows.filter(row => row.id !== userID)
+                setAlert(true)
+                setAlertContent("User cohort request approved")
+                setRows(remainingRows);
+
+                setTimeout(() => {
+                    setAlert(false);
+                }, 3000);
+            }
+            } else {
+                console.log('No user id');
+            }
+        } catch (error) {
+            console.log('Failed to update user cohort request as verified')
+        }
+    }
+  }
+
+  return (
+    <div style={{ height: '80%', width: '50%' }}>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        initialState={{
+          pagination: {
+            paginationModel: { page: 0, pageSize: 10 },
+          },
+        }}
+        pageSizeOptions={[5, 10]}
+        checkboxSelection={true}
+        onRowSelectionModelChange={(newRowSelectionModel) => handleSelection(newRowSelectionModel)}
+        rowSelectionModel={rowSelectionModel}
+      />
+      {alert ? <Alert icon={<CheckIcon fontSize="inherit" />} severity="success">
+        {alertContent}
+      </Alert> : null }
+     
+    </div>
+  );
+}
+
+export default Table

--- a/frontend/src/components/admin/hooks.ts
+++ b/frontend/src/components/admin/hooks.ts
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+import { useAppSelector, useAppDispatch } from '../../app/store.ts'
+import { findUnverifiedCohortRequests } from "./slice.ts";
+
+export const useCohortUserDetails = () => {
+    const { cohortUserDetails } = useAppSelector((state) => state.adminReducer);
+    return cohortUserDetails;
+  };
+
+export const useFetchCohortUserDetails = () => {
+    const dispatch = useAppDispatch();
+    return useCallback(() => {
+        dispatch(findUnverifiedCohortRequests());
+        }, [dispatch]
+    )
+}
+

--- a/frontend/src/components/admin/slice.ts
+++ b/frontend/src/components/admin/slice.ts
@@ -1,0 +1,56 @@
+import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit'
+import { StoreStateType } from '../../app/store'
+import axios from 'axios'
+
+interface CohortUserDetails {
+    cohort_name: string | null,
+    id: number | null,
+    first_name: string | null,
+    last_name: string | null,
+    email: string | null,
+}
+
+export type InitialStateType = {
+    cohortUserDetails: CohortUserDetails[]
+    status: string
+}
+
+const initialState: InitialStateType = {
+    cohortUserDetails: [],
+    status: ''
+}
+
+
+export const findUnverifiedCohortRequests = createAsyncThunk(
+    'admin/findUnverifiedCohortRequests',
+    async() => {
+        const response = await axios.get(import.meta.env.VITE_BACKEND_URL + '/cohorts/unverified')
+        return response.data
+    }
+)
+
+const adminSlice = createSlice({
+    name: 'admin',
+    initialState,
+    reducers: {
+    },
+    extraReducers(builder) {
+        builder
+        .addCase(findUnverifiedCohortRequests.fulfilled, (state, action: PayloadAction<CohortUserDetails[]>) => {
+            state.cohortUserDetails = action.payload
+            state.status = 'succeeded'
+        })
+        .addCase(findUnverifiedCohortRequests.pending, (state) => {
+            state.status = 'loading'
+        })
+        .addCase(findUnverifiedCohortRequests.rejected, (state) => {
+            state.status = 'failed'
+        })
+    }
+})
+
+export const adminState = (state: StoreStateType) => state.adminReducer.cohortUserDetails
+
+export const { } = adminSlice.actions
+
+export default adminSlice.reducer

--- a/frontend/src/components/auth/Auth.tsx
+++ b/frontend/src/components/auth/Auth.tsx
@@ -1,33 +1,56 @@
-
-import { useEffect, useContext, useState } from "react";
+import { useEffect, useContext, useState } from "react"
 import { AuthContext } from "../../App.tsx"
-import axios from 'axios'
+import axios from 'axios';
+import { AuthProviderProps } from "../../types/consts.ts"
 import LoginRegister from "../LoginRegister.tsx"
-import { AuthProviderProps } from "../../types/consts.ts";
 
-const Auth = ({children}: AuthProviderProps) => {
-    const { user } = useContext(AuthContext)
+const Auth = ({ children }: AuthProviderProps) => {
+  const { token, setToken } = useContext(AuthContext)
+  const [redirect, setRedirect] = useState<boolean>(false)
 
-    const [redirect, setRedirect] = useState<boolean>(false)
-
-    useEffect(() => {
-        verify()
-    }, [user])
-
-    const verify = async () => {
-        try {
-            if(user) {
-                const response = await axios.get(import.meta.env.VITE_BACKEND_URL + '/verify', {withCredentials: true})
-                if (response.status === 200) setRedirect(true)
-            } else {
-                setRedirect(false)
-            }
-        } catch {
-            setRedirect(false)
-        }
+  const refreshToken = async () => {
+    try {
+      const response = await axios.get(import.meta.env.VITE_BACKEND_URL + '/refresh', { withCredentials: true });
+      if (response.status === 200) {
+        const newToken = response.data.accessToken
+        setToken(newToken);
+        localStorage.setItem('token', newToken)
+        return newToken;
+      }
+    } catch (error) {
+      console.log("Failed to refresh token", error)
+      return null;
     }
+  };
+  
 
-    return redirect ? children : <LoginRegister page={"Login"}/>
+  const verify = async () => {
+    try {
+      const response = await axios.get(import.meta.env.VITE_BACKEND_URL + '/verify', {
+        withCredentials: true
+      });
+      if (response.status === 200) {
+        setRedirect(true);
+      } else {
+        setRedirect(false);
+      }
+    } catch (error) {
+      setRedirect(false);
+    }
+    if (!redirect && token) {
+      const newToken = await refreshToken()
+      if (newToken) {
+        await verify()
+      }
+    }
+  };
+  
+
+  useEffect(() => {
+    verify();
+  }, [token]);
+
+  return redirect ? children : <LoginRegister page={"Login"} />
 };
 
-export default Auth
+export default Auth;

--- a/frontend/src/components/userDetails/Biography.tsx
+++ b/frontend/src/components/userDetails/Biography.tsx
@@ -61,7 +61,6 @@ const Biography = () => {
         return; 
       }
 
-
       alert('Profile updated successfully');
     } catch (error) {
       console.error('Error updating profile', error);

--- a/frontend/src/components/userDetails/Cohort.tsx
+++ b/frontend/src/components/userDetails/Cohort.tsx
@@ -39,7 +39,7 @@ const Cohort = () => {
         addCohortHook(cohort)
         if(user) {
             updateUserCohortHook(user.id)
-            alert('Request sent. An admin will review your cohort request.');
+            alert('Request sent. An admin will review your cohort request.')
         }
         setCohort("")
   }

--- a/frontend/src/components/userDetails/UserDetailsForm.tsx
+++ b/frontend/src/components/userDetails/UserDetailsForm.tsx
@@ -36,15 +36,11 @@ const UserDetailsForm = () => {
 
   return (
     <div className="container">
-        { stepHook === COHORT  &&
+        { stepHook === COHORT && !user?.isadmin &&
             <Cohort/>
         }
-        { stepHook === BIOGRAPHY &&
+        { (stepHook === BIOGRAPHY || user?.isadmin && stepHook===COHORT) &&
             <Biography />
-        }
-        { stepHook === FINISHED_FORM && user?.isadmin &&
-            // <Admin /> 
-            <h2> admin component</h2>
         }
         { stepHook === FINISHED_FORM &&
             <h2>Form completed</h2>

--- a/frontend/src/types/consts.ts
+++ b/frontend/src/types/consts.ts
@@ -3,6 +3,8 @@ import { ReactNode } from "react";
 export interface AuthContextType {
     user: UserInterface | null,
     setUser: React.Dispatch<React.SetStateAction<UserInterface | null>>
+    token: string | null;
+    setToken: React.Dispatch<React.SetStateAction<string | null>>; 
 }
 
 export type UserInterface = {
@@ -21,4 +23,13 @@ export interface AuthProviderProps {
 export interface HomeProps {
     children: ReactNode;
 }
+
+export interface CohortUserDetails {
+    cohort_name: string | null,
+    id: number | null,
+    first_name: string | null,
+    last_name: string | null,
+    email: string | null,
+}
+
 


### PR DESCRIPTION
An admin needs to accept cohort requests to verify that the student belonged to that cohort. This PR adds the admin feature An admin button is shown in the navbar and /admin endpoint added. Only admin users can access as the route is protected.

Cohort requests are presented in Table or data grid from Material UI. Admin can then select the record they want to approve. User is updated in the db and isverified flips from false to true.

Redux is used to fetch cohort requests from db via async thunk and store in state which is then presented in the admin component via custom hook. Admin component calls the async thunk on mount and requests are passed into Table component via props.

When admin accepts cohort request success alert is shown.

Also this PR enables user & tokens to be persisted after page refresh via local storage. On login, user & token is set, and retrieved to be used within the auth context for children components. On logout, removed. Refresh endpoint queried too so if user has refresh token access is re-signed and re-set in local storage.